### PR TITLE
fix: return securityGroupName on update event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,18 @@ export class SecurityGroup extends aws_ec2.SecurityGroup {
   constructor(scope: Construct, id: string, props: SecurityGroupProps) {
     super(scope, id, props);
 
-    const securityGroup = new custom_resources.AwsCustomResource(this, "DescribeSGCustomResource", {
-      onCreate: {
-        service: "EC2",
-        action: "describeSecurityGroups", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#describeSecurityGroups-property
-        parameters: {
-          GroupIds: [this.securityGroupId],
-        },
-        physicalResourceId: custom_resources.PhysicalResourceId.of(this.securityGroupId),
+    const sdkCall: custom_resources.AwsSdkCall = {
+      service: "EC2",
+      action: "describeSecurityGroups", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#describeSecurityGroups-property
+      parameters: {
+        GroupIds: [this.securityGroupId],
       },
+      physicalResourceId: custom_resources.PhysicalResourceId.of(this.securityGroupId),
+    };
+
+    const securityGroup = new custom_resources.AwsCustomResource(this, "DescribeSGCustomResource", {
+      onCreate: sdkCall,
+      onUpdate: sdkCall,
       policy: custom_resources.AwsCustomResourcePolicy.fromSdkCalls({
         resources: custom_resources.AwsCustomResourcePolicy.ANY_RESOURCE,
       }),

--- a/test/__snapshots__/security-group.test.ts.snap
+++ b/test/__snapshots__/security-group.test.ts.snap
@@ -116,6 +116,28 @@ Object {
             "Arn",
           ],
         },
+        "Update": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"EC2\\",\\"action\\":\\"describeSecurityGroups\\",\\"parameters\\":{\\"GroupIds\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "id4D1900E5",
+                  "GroupId",
+                ],
+              },
+              "\\"]},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "id4D1900E5",
+                  "GroupId",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
       },
       "Type": "Custom::AWS",
       "UpdateReplacePolicy": "Delete",


### PR DESCRIPTION
When an already existing SecurityGroup is updated (let's say for example you change the description property) the following error appears:

```
CustomResource attribute error: Vendor response doesn't contain SecurityGroups.0.GroupName key in object 
```

This happens because the AWS CustomResource currently only executes for the `create` request type but not for the `update` request type.

This PR also fixed https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/638
